### PR TITLE
[PATCH] Added fPIC compile option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ add_library(jsonxx STATIC
         ${CMAKE_CURRENT_SOURCE_DIR}/jsonxx.cc
         )
 
+target_compile_options(jsonxx PRIVATE -fPIC)
+
 target_include_directories(jsonxx
         PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
Added compile option to avoid error with shared library linking
target_compile_options(jsonxx PRIVATE -fPIC)